### PR TITLE
fix(signing): allow timestamp.sigstore.dev:443 endpoint on hardened runner config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
+            timestamp.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
 
       - name: 🚚 Check out the repository


### PR DESCRIPTION
…unner config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to expand authorised outbound network permissions for additional security service endpoints, enhancing build verification and release integrity assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->