### PR TITLE
chore(signing): sign all images, only upload on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,11 +126,9 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: ✍️ Sign the Docker Hub images
-        if: ${{ github.event_name == 'release' }}
         run: |
-          cosign sign --recursive --yes "${{ vars.DOCKER_USERNAME }}/${{ vars.DOCKER_PROJECT }}@${{ steps.build.outputs.digest }}"
+          cosign sign --upload=${{ github.event_name == 'release' }} --recursive --yes "${{ vars.DOCKER_USERNAME }}/${{ vars.DOCKER_PROJECT }}@${{ steps.build.outputs.digest }}"
 
       - name: ✍️ Sign the GitHub Container Registry images
-        if: ${{ github.event_name == 'release' }}
         run: |
-          cosign sign --recursive --yes "ghcr.io/${GITHUB_REPOSITORY@L}@${{ steps.build.outputs.digest }}"
+          cosign sign --upload=${{ github.event_name == 'release' }} --recursive --yes "ghcr.io/${GITHUB_REPOSITORY@L}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow efficiency by refactoring signing step execution. Signing steps now run for all build events with conditional upload handling, reducing configuration complexity whilst maintaining release-specific upload behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->