### PR TITLE
fix(api): clone body into cloned request

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -55,6 +55,7 @@ type Worker struct {
 	logger      *slog.Logger
 	client      *http.Client
 	baseRequest *http.Request
+	body        []byte
 	interval    time.Duration
 }
 
@@ -92,6 +93,7 @@ func newWorker(ctx context.Context, targetServer *entity.TargetServer, client *h
 		client:      client,
 		wg:          wg,
 		logger:      jobLogger,
+		body:        body,
 		interval:    targetServer.Interval,
 		baseRequest: req,
 	}, nil
@@ -123,6 +125,7 @@ func (w *Worker) run() {
 
 func (w *Worker) sendWakeRequest() {
 	req := w.baseRequest.Clone(w.ctx)
+	req.Body = io.NopCloser(bytes.NewReader(w.body))
 
 	resp, err := w.client.Do(req)
 


### PR DESCRIPTION
By default the request.Clone() method does not actually clone the body of the request. This needs to be done in order to avoid `http: ContentLength=27 with Body length 0` errors

https://stackoverflow.com/questions/62017146/http-request-clone-is-not-deep-clone