### PR TITLE
 feat(logging): adds target name and evaluation result to slog middleware logger

### DIFF
--- a/cmd/upswake/root.go
+++ b/cmd/upswake/root.go
@@ -19,7 +19,10 @@ It uses the status of a UPS to determine which servers to wake
 using a set of Rego rules defined and the servers in the config file`
 )
 
-var Version string
+var (
+	Version  string
+	LogLevel slog.LevelVar
+)
 
 func NewRootCommand() *cobra.Command {
 	// represents the base command when called without any subcommands
@@ -34,12 +37,14 @@ func NewRootCommand() *cobra.Command {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(ctx context.Context, fs, regoFs afero.Fs, logDestination io.Writer, args []string) int {
-	handler := slog.NewJSONHandler(logDestination, nil)
+	handler := slog.NewJSONHandler(logDestination, &slog.HandlerOptions{
+		Level: LogLevel.Level(),
+	})
 	logger := slog.New(handler)
 
 	bc, err := network.GetAllBroadcastAddresses()
 	if err != nil {
-		logger.Error(
+		slog.Error(
 			"error getting broadcast addresses",
 			slog.String("cmd", "root"),
 			slog.Any("error", err),
@@ -63,7 +68,7 @@ func Execute(ctx context.Context, fs, regoFs afero.Fs, logDestination io.Writer,
 
 	err = rootCmd.ExecuteContext(ctx)
 	if err != nil {
-		logger.Error(
+		slog.Error(
 			"Error executing root command",
 			slog.String("cmd", "root"),
 			slog.Any("error", err),

--- a/cmd/upswake/root.go
+++ b/cmd/upswake/root.go
@@ -44,7 +44,7 @@ func Execute(ctx context.Context, fs, regoFs afero.Fs, logDestination io.Writer,
 
 	bc, err := network.GetAllBroadcastAddresses()
 	if err != nil {
-		slog.Error(
+		logger.Error(
 			"error getting broadcast addresses",
 			slog.String("cmd", "root"),
 			slog.Any("error", err),
@@ -68,7 +68,7 @@ func Execute(ctx context.Context, fs, regoFs afero.Fs, logDestination io.Writer,
 
 	err = rootCmd.ExecuteContext(ctx)
 	if err != nil {
-		slog.Error(
+		logger.Error(
 			"Error executing root command",
 			slog.String("cmd", "root"),
 			slog.Any("error", err),

--- a/cmd/upswake/serve.go
+++ b/cmd/upswake/serve.go
@@ -94,6 +94,9 @@ func (j *serveCMD) serveCmdRunE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error loading config: %w", err)
 	}
 
+	j.logger.Info("setting logging level", slog.String("level", cfg.Logging.Level.String()))
+	LogLevel.Set(cfg.Logging.Level)
+
 	ruleRepo, err := rules.NewPreparedRepository(j.regoFs)
 	if err != nil {
 		return fmt.Errorf("error compiling rego rules: %w", err)

--- a/cmd/upswake/serve.go
+++ b/cmd/upswake/serve.go
@@ -106,17 +106,17 @@ func (j *serveCMD) serveCmdRunE(cmd *cobra.Command, _ []string) error {
 
 	if cfg.Profiler.Enabled {
 		j.logger.Warn("Profiler enabled")
-		profilerHandler := handlers.NewProfilerHandler()
+		profilerHandler := handlers.NewProfilerHandler(j.logger)
 		profilerHandler.Register(server.Root().Group("/debug/pprof"))
 	}
 
-	rootHandler := handlers.NewRootHandler(cfg, j.regoFs, cachedUpsRepo)
+	rootHandler := handlers.NewRootHandler(cfg, j.logger, j.regoFs, cachedUpsRepo)
 	rootHandler.Register(server.Root())
 
-	serverHandler := handlers.NewServerHandler()
+	serverHandler := handlers.NewServerHandler(j.logger)
 	serverHandler.Register(server.API().Group("/servers"))
 
-	upsWakeHandler := handlers.NewUPSWakeHandler(cfg, cachedUpsRepo, ruleRepo)
+	upsWakeHandler := handlers.NewUPSWakeHandler(cfg, j.logger, cachedUpsRepo, ruleRepo)
 	upsWakeHandler.Register(server.API().Group("/upswake"))
 
 	workerPool, err := worker.NewWorkerPool(ctx, cfg, cliArgs.TLSConfig, j.logger, fmt.Sprintf("%s/api/upswake", cliArgs.URL()))

--- a/cmd/upswake/serve_test.go
+++ b/cmd/upswake/serve_test.go
@@ -108,7 +108,7 @@ nut_servers:
 				`"msg":"Starting worker","cmd":"serve","type":"serveJob","worker_name":"test-target-server"`,
 				`"status":200`,
 				`"level":"INFO"`,
-				`"msg":"REQUEST","cmd":"serve","remote_ip":"127.0.0.1","host":"127.0.0.1:8082","method":"POST","uri":"/api/upswake","user_agent":"Go-http-client/1.1","status":200}`,
+				`"msg":"REQUEST","cmd":"serve","remote_ip":"127.0.0.1","host":"127.0.0.1:8082","method":"POST","uri":"/api/upswake","user_agent":"Go-http-client/1.1","status":200`,
 			},
 			notWantOutputs: []string{
 				`"level":"ERROR"`,

--- a/cmd/upswake/serve_test.go
+++ b/cmd/upswake/serve_test.go
@@ -108,7 +108,7 @@ nut_servers:
 				`"msg":"Starting worker","cmd":"serve","type":"serveJob","worker_name":"test-target-server"`,
 				`"status":200`,
 				`"level":"INFO"`,
-				`"msg":"REQUEST","cmd":"serve","remote_ip":"127.0.0.1","host":"127.0.0.1:8082","method":"POST","uri":"/api/upswake","user_agent":"Go-http-client/1.1","status":200`,
+				`"msg":"REQUEST","cmd":"serve","remote_ip":"127.0.0.1","host":"127.0.0.1:8082","method":"POST","uri":"/api/upswake","user_agent":"Go-http-client/1.1","status":200,"target":"test-target-server","evaluation":false,"woken":false`,
 			},
 			notWantOutputs: []string{
 				`"level":"ERROR"`,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TheDarthMole/UPSWake
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-playground/validator/v10 v10.30.3

--- a/internal/api/handlers/profiler.go
+++ b/internal/api/handlers/profiler.go
@@ -1,16 +1,21 @@
 package handlers
 
 import (
+	"log/slog"
 	"net/http"
 	"net/http/pprof"
 
 	"github.com/labstack/echo/v5"
 )
 
-type ProfilerHandler struct{}
+type ProfilerHandler struct {
+	logger *slog.Logger
+}
 
-func NewProfilerHandler() *ProfilerHandler {
-	return &ProfilerHandler{}
+func NewProfilerHandler(logger *slog.Logger) *ProfilerHandler {
+	return &ProfilerHandler{
+		logger: logger,
+	}
 }
 
 // Register middleware for net/http/pprof

--- a/internal/api/handlers/profiler_test.go
+++ b/internal/api/handlers/profiler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,8 +30,9 @@ func TestPProfRegisterDefaultPrefix(t *testing.T) {
 	for _, tt := range pprofPaths {
 		t.Run(tt.path, func(t *testing.T) {
 			e := echo.New()
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 
-			profilerHandler := NewProfilerHandler()
+			profilerHandler := NewProfilerHandler(logger)
 			profilerHandler.Register(e.Group(""))
 			req, _ := http.NewRequest(http.MethodGet, tt.path, http.NoBody)
 			rec := httptest.NewRecorder()
@@ -61,10 +63,11 @@ func TestPProfRegisterCustomPrefix(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			t.Parallel()
 			e := echo.New()
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 
 			prefix := "/test/profiler"
 
-			profilerHandler := NewProfilerHandler()
+			profilerHandler := NewProfilerHandler(logger)
 			profilerHandler.Register(e.Group(prefix))
 			req, _ := http.NewRequest(http.MethodGet, prefix+tt.path, http.NoBody)
 			rec := httptest.NewRecorder()

--- a/internal/api/handlers/root.go
+++ b/internal/api/handlers/root.go
@@ -80,32 +80,36 @@ func (*RootHandler) Root(c *echo.Context) error {
 //	@Failure		500	{object}	Response
 //	@Router			/health [get]
 func (h *RootHandler) Health(c *echo.Context) error {
+	h.logger.Debug("Checking health")
 	if err := h.cfg.Validate(); err != nil {
 		return c.JSON(http.StatusInternalServerError, Response{Message: err.Error()})
 	}
 
 	if _, err := network.GetAllBroadcastAddresses(); err != nil {
-		c.Logger().Error("Error getting broadcast addresses", slog.Any("error", err))
+		h.logger.Error("Error getting broadcast addresses", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, Response{Message: err.Error()})
 	}
+	h.logger.Debug("Received broadcast addresses from attached network interfaces")
 
 	g := errgroup.Group{}
 
 	for _, server := range h.cfg.NutServers {
 		g.Go(func() error {
+			h.logger.Debug("Retrieving JSON from NUT server", slog.Any("server", server.Name))
 			if _, err := h.upsRepo.GetJSON(server); err != nil {
-				c.Logger().Error("Error getting NUT server status", slog.Any("error", err))
+				h.logger.Error("Error getting NUT server status", slog.Any("error", err))
 				return err
 			}
+			h.logger.Debug("Retrieved JSON from NUT server", slog.Any("server", server.Name))
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		c.Logger().Error("Health check failed", slog.Any("error", err))
+		h.logger.Error("Health check failed", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, Response{Message: err.Error()})
 	}
 
-	c.Logger().Debug("Health check OK")
+	h.logger.Debug("Health check OK")
 	return c.JSON(http.StatusOK, Response{Message: "OK"})
 }

--- a/internal/api/handlers/root.go
+++ b/internal/api/handlers/root.go
@@ -19,6 +19,7 @@ type RootHandler struct {
 	cfg     *entity.Config
 	rulesFS afero.Fs
 	upsRepo repository.UPSRepository
+	logger  *slog.Logger
 }
 
 type Response struct {
@@ -31,11 +32,12 @@ type Response struct {
 //	@Title			UPSWake
 //	@Version		1.0
 //	@Description	UPSWake reads data from a UPS Nut Server and uses it to dynamically send Wake on Lan packets to servers
-func NewRootHandler(cfg *entity.Config, rulesFS afero.Fs, upsRepo repository.UPSRepository) *RootHandler {
+func NewRootHandler(cfg *entity.Config, logger *slog.Logger, rulesFS afero.Fs, upsRepo repository.UPSRepository) *RootHandler {
 	return &RootHandler{
 		cfg:     cfg,
 		rulesFS: rulesFS,
 		upsRepo: upsRepo,
+		logger:  logger,
 	}
 }
 

--- a/internal/api/handlers/root.go
+++ b/internal/api/handlers/root.go
@@ -3,8 +3,6 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/TheDarthMole/UPSWake/internal/domain/entity"
 	"github.com/TheDarthMole/UPSWake/internal/domain/repository"
@@ -39,15 +37,6 @@ func NewRootHandler(cfg *entity.Config, logger *slog.Logger, rulesFS afero.Fs, u
 		upsRepo: upsRepo,
 		logger:  logger,
 	}
-}
-
-func sanitizeString(input string) string {
-	// Replace any non-printable characters with an empty string
-	sanitised := strconv.QuoteToASCII(input)
-	sanitised = strings.TrimSpace(sanitised)
-	sanitised = strings.ReplaceAll(sanitised, "\n", "")
-	sanitised = strings.ReplaceAll(sanitised, "\r", "")
-	return sanitised
 }
 
 func (h *RootHandler) Register(g *echo.Group) {

--- a/internal/api/handlers/root_test.go
+++ b/internal/api/handlers/root_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -65,13 +66,14 @@ func newMemFS(t *testing.T, data map[string][]byte) afero.Fs {
 
 func TestRootHandlerRoot(t *testing.T) {
 	e := echo.New()
+	logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 	e.Validator = api.NewCustomValidator(t.Context())
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
 	rulesFS := newMemFS(t, map[string][]byte{})
-	h := NewRootHandler(testConfig(t), rulesFS, &countingUPSRepo{})
+	h := NewRootHandler(testConfig(t), logger, rulesFS, &countingUPSRepo{})
 
 	if assert.NoError(t, h.Root(c)) {
 		assert.Equal(t, http.StatusMovedPermanently, rec.Code)
@@ -187,13 +189,14 @@ func TestRootHandler_Health(t *testing.T) {
 		// 		    and test when the GetAllBroadcastAddresses fails
 	}
 	e := echo.New()
+	logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 	e.Validator = api.NewCustomValidator(t.Context())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
-			h := NewRootHandler(tt.fields.cfg, tt.fields.rulesFS, tt.fields.upsRepo)
+			h := NewRootHandler(tt.fields.cfg, logger, tt.fields.rulesFS, tt.fields.upsRepo)
 
 			if assert.NoError(t, h.Health(c)) {
 				assert.Equal(t, tt.wantedResponse.statusCode, rec.Code)
@@ -205,9 +208,10 @@ func TestRootHandler_Health(t *testing.T) {
 
 func TestRootHandler_Register(t *testing.T) {
 	e := echo.New()
+	logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 	e.Validator = api.NewCustomValidator(t.Context())
 	rulesFS := newMemFS(t, map[string][]byte{})
-	h := NewRootHandler(testConfig(t), rulesFS, &countingUPSRepo{})
+	h := NewRootHandler(testConfig(t), logger, rulesFS, &countingUPSRepo{})
 
 	g := e.Group("")
 	h.Register(g)
@@ -239,6 +243,7 @@ func TestNewRootHandler(t *testing.T) {
 		cfg     *entity.Config
 		rulesFS afero.Fs
 		upsRepo repository.UPSRepository
+		logger  *slog.Logger
 	}
 	emptyFS := newMemFS(t, map[string][]byte{})
 	ruleOneFS := newMemFS(t, map[string][]byte{
@@ -258,6 +263,7 @@ default wake := true`),
 				upsRepo: &countingUPSRepo{
 					json: `[{"Name":"ups1"}]`,
 				},
+				logger: slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{})),
 			},
 			want: &RootHandler{
 				cfg:     testConfig(t),
@@ -265,6 +271,7 @@ default wake := true`),
 				upsRepo: &countingUPSRepo{
 					json: `[{"Name":"ups1"}]`,
 				},
+				logger: slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{})),
 			},
 		},
 		{
@@ -321,7 +328,7 @@ default wake := true`),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, NewRootHandler(tt.args.cfg, tt.args.rulesFS, tt.args.upsRepo), "NewRootHandler(%v, %v)", tt.args.cfg, tt.args.rulesFS)
+			assert.Equalf(t, tt.want, NewRootHandler(tt.args.cfg, tt.args.logger, tt.args.rulesFS, tt.args.upsRepo), "NewRootHandler(%v, %v)", tt.args.cfg, tt.args.rulesFS)
 		})
 	}
 }

--- a/internal/api/handlers/servers.go
+++ b/internal/api/handlers/servers.go
@@ -29,6 +29,7 @@ const (
 type ServerHandler struct {
 	newTargetServer    func(name, mac, broadcast string, interval time.Duration, port int, rules []string) (*entity.TargetServer, error)
 	broadcastAddresses func() ([]net.IP, error)
+	logger             *slog.Logger
 }
 
 type WakeServerRequest struct {
@@ -54,10 +55,11 @@ func NewBroadcastWakeRequest() *BroadcastWakeRequest {
 	}
 }
 
-func NewServerHandler() *ServerHandler {
+func NewServerHandler(logger *slog.Logger) *ServerHandler {
 	return &ServerHandler{
 		newTargetServer:    entity.NewTargetServer,
 		broadcastAddresses: network.GetAllBroadcastAddresses,
+		logger:             logger,
 	}
 }
 

--- a/internal/api/handlers/servers.go
+++ b/internal/api/handlers/servers.go
@@ -83,12 +83,12 @@ func (s *ServerHandler) Register(g *echo.Group) {
 func (s *ServerHandler) WakeServer(c *echo.Context) error {
 	wsRequest := NewWakeServerRequest()
 	if err := c.Bind(wsRequest); err != nil {
-		c.Logger().Error("failed to bind wake server request", slog.Any("error", err))
+		s.logger.Error("failed to bind wake server request", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, Response{Message: ErrorBindingRequest.Error()})
 	}
 
 	if err := c.Validate(wsRequest); err != nil {
-		c.Logger().Error("failed to validate wake server request", slog.Any("error", err))
+		s.logger.Error("failed to validate wake server request", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, Response{Message: ErrorValidatingRequest.Error()})
 	}
 
@@ -101,18 +101,18 @@ func (s *ServerHandler) WakeServer(c *echo.Context) error {
 		[]string{},
 	)
 	if err != nil {
-		c.Logger().Error("failed to create target server", slog.Any("error", err))
+		s.logger.Error("failed to create target server", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, Response{Message: ErrorCreatingTargetServer.Error()})
 	}
 
 	wolClient := wol.NewWoLClient(ts)
 
 	if err = wolClient.Wake(); err != nil {
-		c.Logger().Error("failed to send wake on lan", slog.Any("error", err))
+		s.logger.Error("failed to send wake on lan", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, Response{Message: ErrorSendingWoLPacket.Error()})
 	}
 
-	c.Logger().Info("wake on lan packet sent", slog.String("mac", sanitizeString(wsRequest.Mac)))
+	s.logger.Info("wake on lan packet sent", slog.String("mac", sanitizeString(wsRequest.Mac)))
 	return c.JSON(http.StatusCreated, Response{Message: WoLSentMessage})
 }
 
@@ -131,28 +131,28 @@ func (s *ServerHandler) WakeServer(c *echo.Context) error {
 func (s *ServerHandler) BroadcastWakeServer(c *echo.Context) error {
 	wsRequest := NewBroadcastWakeRequest()
 	if err := c.Bind(wsRequest); err != nil {
-		c.Logger().Error("failed to bind wake server request", slog.Any("error", err))
+		s.logger.Error("failed to bind wake server request", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, Response{Message: ErrorBindingRequest.Error()})
 	}
 
 	if err := c.Validate(wsRequest); err != nil {
-		c.Logger().Error("failed to validate wake server request", slog.Any("error", err))
+		s.logger.Error("failed to validate wake server request", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, Response{Message: ErrorValidatingRequest.Error()})
 	}
 	broadcasts, err := s.broadcastAddresses()
 	if err != nil {
-		c.Logger().Error("failed to get broadcast addresses", slog.Any("error", err))
+		s.logger.Error("failed to get broadcast addresses", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, Response{Message: ErrorBroadcastAddress.Error()})
 	}
 
 	if len(broadcasts) == 0 {
-		c.Logger().Error("no broadcast addresses available", slog.Any("broadcasts", broadcasts))
+		s.logger.Error("no broadcast addresses available", slog.Any("broadcasts", broadcasts))
 		return c.JSON(http.StatusInternalServerError, Response{Message: ErrorBroadcastAddress.Error()})
 	}
 
 	for _, broadcast := range broadcasts {
 		if broadcast == nil {
-			c.Logger().Error("invalid broadcast address")
+			s.logger.Error("invalid broadcast address")
 			return c.JSON(http.StatusInternalServerError, Response{Message: ErrorBroadcastAddress.Error()})
 		}
 
@@ -165,16 +165,16 @@ func (s *ServerHandler) BroadcastWakeServer(c *echo.Context) error {
 			[]string{},
 		)
 		if err != nil {
-			c.Logger().Error("failed to create new target server", slog.Any("error", err))
+			s.logger.Error("failed to create new target server", slog.Any("error", err))
 			return c.JSON(http.StatusInternalServerError, Response{Message: ErrorCreatingTargetServer.Error()})
 		}
 
 		wolClient := wol.NewWoLClient(ts)
 		if err = wolClient.Wake(); err != nil {
-			c.Logger().Error("failed to send wake on lan", slog.Any("error", err))
+			s.logger.Error("failed to send wake on lan", slog.Any("error", err))
 			return c.JSON(http.StatusInternalServerError, Response{Message: ErrorSendingWoLPacket.Error()})
 		}
-		c.Logger().Info("sent wake on lan",
+		s.logger.Info("sent wake on lan",
 			slog.String("mac", sanitizeString(wsRequest.Mac)),
 			slog.Int("port", wsRequest.Port),
 			slog.String("broadcast", broadcast.String()))

--- a/internal/api/handlers/servers.go
+++ b/internal/api/handlers/servers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/TheDarthMole/UPSWake/internal/domain/entity"
+	"github.com/TheDarthMole/UPSWake/internal/logging"
 	"github.com/TheDarthMole/UPSWake/internal/network"
 	"github.com/TheDarthMole/UPSWake/internal/wol"
 	"github.com/labstack/echo/v5"
@@ -112,7 +113,7 @@ func (s *ServerHandler) WakeServer(c *echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, Response{Message: ErrorSendingWoLPacket.Error()})
 	}
 
-	s.logger.Info("wake on lan packet sent", slog.String("mac", sanitizeString(wsRequest.Mac)))
+	s.logger.Info("wake on lan packet sent", slog.String("mac", logging.SanitizeString(wsRequest.Mac)))
 	return c.JSON(http.StatusCreated, Response{Message: WoLSentMessage})
 }
 
@@ -175,7 +176,7 @@ func (s *ServerHandler) BroadcastWakeServer(c *echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, Response{Message: ErrorSendingWoLPacket.Error()})
 		}
 		s.logger.Info("sent wake on lan",
-			slog.String("mac", sanitizeString(wsRequest.Mac)),
+			slog.String("mac", logging.SanitizeString(wsRequest.Mac)),
 			slog.Int("port", wsRequest.Port),
 			slog.String("broadcast", broadcast.String()))
 	}

--- a/internal/api/handlers/servers_test.go
+++ b/internal/api/handlers/servers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,8 @@ func mockValidBroadcastAddressesFunc() ([]net.IP, error) {
 
 func TestServerHandler_Register(t *testing.T) {
 	e := echo.New()
-	h := NewServerHandler()
+	logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
+	h := NewServerHandler(logger)
 
 	g := e.Group("")
 	h.Register(g)

--- a/internal/api/handlers/servers_test.go
+++ b/internal/api/handlers/servers_test.go
@@ -220,12 +220,14 @@ func TestServerHandler_BroadcastWakeServer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/broadcastwake", strings.NewReader(tt.fields.body))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 			h := &ServerHandler{
 				newTargetServer:    tt.fields.mockNewTargetServer,
 				broadcastAddresses: tt.fields.mockBroadcastAddresses,
+				logger:             logger,
 			}
 
 			if assert.NoError(t, h.BroadcastWakeServer(c)) {
@@ -350,8 +352,10 @@ func TestServerHandler_WakeServer(t *testing.T) {
 
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 			h := &ServerHandler{
 				newTargetServer: tt.fields.mockNewTargetServer,
+				logger:          logger,
 			}
 
 			if assert.NoError(t, h.WakeServer(c)) {

--- a/internal/api/handlers/slog.go
+++ b/internal/api/handlers/slog.go
@@ -6,6 +6,6 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
-func setSlogAttributes(c *echo.Context, attributes []slog.Attr) {
+func setRequestLoggerAttrs(c *echo.Context, attributes []slog.Attr) {
 	c.Set("request_logger_values", attributes)
 }

--- a/internal/api/handlers/slog.go
+++ b/internal/api/handlers/slog.go
@@ -1,0 +1,11 @@
+package handlers
+
+import (
+	"log/slog"
+
+	"github.com/labstack/echo/v5"
+)
+
+func setSlogAttributes(c *echo.Context, attributes []slog.Attr) {
+	c.Set("request_logger_values", attributes)
+}

--- a/internal/api/handlers/upswake.go
+++ b/internal/api/handlers/upswake.go
@@ -86,7 +86,7 @@ func (h *UPSWakeHandler) ListNutServerMappings(c *echo.Context) error {
 func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	request := &WakeEvaluationRequest{}
 	if err := c.Bind(request); err != nil {
-		c.Logger().Error("failed to bind mac address", slog.Any("error", err))
+		h.logger.Error("failed to bind mac address", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, UpsWakeResponse{
 			Message: ErrorBindingRequest.Error(),
 			Woken:   false,
@@ -94,7 +94,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	}
 	mac, err := entity.NewMacAddress(request.Mac)
 	if err != nil {
-		c.Logger().Error("failed to validate mac address", slog.Any("error", err))
+		h.logger.Error("failed to validate mac address", slog.Any("error", err))
 		return c.JSON(http.StatusBadRequest, UpsWakeResponse{
 			Message: err.Error(),
 			Woken:   false,
@@ -104,7 +104,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	eval := evaluator.NewRegoEvaluator(h.cfg, mac, h.upsRepo, h.ruleRepo)
 	result, err := eval.EvaluateExpressions()
 	if err != nil {
-		c.Logger().Error("Failed to evaluate expressions", slog.Any("error", err))
+		h.logger.Error("Failed to evaluate expressions", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, UpsWakeResponse{
 			Message: err.Error(),
 			Woken:   false,
@@ -112,7 +112,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	}
 
 	if !result.Found {
-		c.Logger().Error("mac address not found in the config", slog.String("mac", mac.MAC))
+		h.logger.Error("mac address not found in the config", slog.String("mac", mac.MAC))
 		return c.JSON(http.StatusConflict, UpsWakeResponse{
 			Message: "MAC address not found in the config",
 			Woken:   false,
@@ -120,12 +120,25 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	}
 
 	if !result.Allowed {
-		c.Logger().Debug("no rule evaluated to true", slog.String("mac", mac.MAC))
+		h.logger.Debug("no rule evaluated to true",
+			slog.String("mac", mac.MAC),
+			slog.String("target", result.Target.Name))
+
+		setSlogAttributes(c, []slog.Attr{
+			slog.String("target", result.Target.Name),
+			slog.Bool("evaluation", false),
+		})
+
 		return c.JSON(http.StatusOK, UpsWakeResponse{
 			Message: "No rule evaluated to true",
 			Woken:   false,
 		})
 	}
+
+	setSlogAttributes(c, []slog.Attr{
+		slog.String("target", result.Target.Name),
+		slog.Bool("evaluation", true),
+	})
 
 	ts, err := entity.NewTargetServer(
 		"API Request",
@@ -136,7 +149,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 		[]string{},
 	)
 	if err != nil {
-		c.Logger().Error("Failed to create target server", slog.Any("error", err))
+		h.logger.Error("Failed to create target server", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, UpsWakeResponse{
 			Message: fmt.Sprintf("Failed to create target server: %s", err),
 			Woken:   false,
@@ -146,14 +159,14 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	wolClient := wol.NewWoLClient(ts)
 
 	if err = wolClient.Wake(); err != nil {
-		c.Logger().Error("Failed to send wake on lan", slog.Any("error", err))
+		h.logger.Error("Failed to send wake on lan", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, UpsWakeResponse{
 			Message: fmt.Sprintf("Failed to send wake on LAN: %s", err),
 			Woken:   false,
 		})
 	}
 
-	c.Logger().Debug("Wake on LAN sent", slog.String("mac", mac.MAC))
+	h.logger.Debug("Wake on LAN sent", slog.String("mac", mac.MAC))
 	return c.JSON(http.StatusOK, UpsWakeResponse{
 		Message: "Wake on LAN sent",
 		Woken:   true,

--- a/internal/api/handlers/upswake.go
+++ b/internal/api/handlers/upswake.go
@@ -16,6 +16,7 @@ import (
 
 type UPSWakeHandler struct {
 	cfg      *entity.Config
+	logger   *slog.Logger
 	upsRepo  repository.UPSRepository
 	ruleRepo repository.RuleRepository
 }
@@ -31,11 +32,12 @@ type UpsWakeResponse struct {
 
 // NewUPSWakeHandler creates a UPSWakeHandler configured with the supplied server configuration and repositories.
 // The returned handler holds cfg, upsRepo and ruleRepo for use by its HTTP endpoints.
-func NewUPSWakeHandler(cfg *entity.Config, upsRepo repository.UPSRepository, ruleRepo repository.RuleRepository) *UPSWakeHandler {
+func NewUPSWakeHandler(cfg *entity.Config, logger *slog.Logger, upsRepo repository.UPSRepository, ruleRepo repository.RuleRepository) *UPSWakeHandler {
 	return &UPSWakeHandler{
 		cfg:      cfg,
 		upsRepo:  upsRepo,
 		ruleRepo: ruleRepo,
+		logger:   logger,
 	}
 }
 

--- a/internal/api/handlers/upswake.go
+++ b/internal/api/handlers/upswake.go
@@ -124,9 +124,10 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 			slog.String("mac", mac.MAC),
 			slog.String("target", result.Target.Name))
 
-		setSlogAttributes(c, []slog.Attr{
+		setRequestLoggerAttrs(c, []slog.Attr{
 			slog.String("target", result.Target.Name),
 			slog.Bool("evaluation", false),
+			slog.Bool("woken", false),
 		})
 
 		return c.JSON(http.StatusOK, UpsWakeResponse{
@@ -134,11 +135,6 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 			Woken:   false,
 		})
 	}
-
-	setSlogAttributes(c, []slog.Attr{
-		slog.String("target", result.Target.Name),
-		slog.Bool("evaluation", true),
-	})
 
 	ts, err := entity.NewTargetServer(
 		"API Request",
@@ -150,6 +146,13 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	)
 	if err != nil {
 		h.logger.Error("Failed to create target server", slog.Any("error", err))
+
+		setRequestLoggerAttrs(c, []slog.Attr{
+			slog.String("target", result.Target.Name),
+			slog.Bool("evaluation", true),
+			slog.Bool("woken", false),
+		})
+
 		return c.JSON(http.StatusInternalServerError, UpsWakeResponse{
 			Message: fmt.Sprintf("Failed to create target server: %s", err),
 			Woken:   false,
@@ -160,6 +163,13 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 
 	if err = wolClient.Wake(); err != nil {
 		h.logger.Error("Failed to send wake on lan", slog.Any("error", err))
+
+		setRequestLoggerAttrs(c, []slog.Attr{
+			slog.String("target", result.Target.Name),
+			slog.Bool("evaluation", true),
+			slog.Bool("woken", false),
+		})
+
 		return c.JSON(http.StatusInternalServerError, UpsWakeResponse{
 			Message: fmt.Sprintf("Failed to send wake on LAN: %s", err),
 			Woken:   false,
@@ -167,6 +177,13 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	}
 
 	h.logger.Debug("Wake on LAN sent", slog.String("mac", mac.MAC))
+
+	setRequestLoggerAttrs(c, []slog.Attr{
+		slog.String("target", result.Target.Name),
+		slog.Bool("evaluation", true),
+		slog.Bool("woken", true),
+	})
+
 	return c.JSON(http.StatusOK, UpsWakeResponse{
 		Message: "Wake on LAN sent",
 		Woken:   true,

--- a/internal/api/handlers/upswake.go
+++ b/internal/api/handlers/upswake.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheDarthMole/UPSWake/internal/domain/repository"
 	"github.com/TheDarthMole/UPSWake/internal/evaluator"
 	"github.com/TheDarthMole/UPSWake/internal/infrastructure/config/viper"
+	"github.com/TheDarthMole/UPSWake/internal/logging"
 	"github.com/TheDarthMole/UPSWake/internal/wol"
 	"github.com/labstack/echo/v5"
 )
@@ -112,7 +113,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 	}
 
 	if !result.Found {
-		h.logger.Error("mac address not found in the config", slog.String("mac", mac.MAC))
+		h.logger.Error("mac address not found in the config", slog.String("mac", logging.SanitizeString(mac.MAC)))
 		return c.JSON(http.StatusConflict, UpsWakeResponse{
 			Message: "MAC address not found in the config",
 			Woken:   false,
@@ -121,7 +122,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 
 	if !result.Allowed {
 		h.logger.Debug("no rule evaluated to true",
-			slog.String("mac", mac.MAC),
+			slog.String("mac", logging.SanitizeString(mac.MAC)),
 			slog.String("target", result.Target.Name))
 
 		setRequestLoggerAttrs(c, []slog.Attr{
@@ -176,7 +177,7 @@ func (h *UPSWakeHandler) RunWakeEvaluation(c *echo.Context) error {
 		})
 	}
 
-	h.logger.Debug("Wake on LAN sent", slog.String("mac", mac.MAC))
+	h.logger.Debug("Wake on LAN sent", slog.String("mac", logging.SanitizeString(mac.MAC)))
 
 	setRequestLoggerAttrs(c, []slog.Attr{
 		slog.String("target", result.Target.Name),

--- a/internal/api/handlers/upswake_test.go
+++ b/internal/api/handlers/upswake_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -221,7 +222,9 @@ func TestUPSWakeHandler_RunWakeEvaluation(t *testing.T) {
 
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
-			h := NewUPSWakeHandler(tt.fields.cfg, upsRepo, ruleRepo)
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
+
+			h := NewUPSWakeHandler(tt.fields.cfg, logger, upsRepo, ruleRepo)
 
 			if assert.NoError(t, h.RunWakeEvaluation(c)) {
 				assert.JSONEq(t, tt.wantedResponse.body, rec.Body.String())
@@ -235,13 +238,14 @@ func TestUPSWakeHandler_Register(t *testing.T) {
 	config := &entity.Config{}
 
 	e := echo.New()
+	logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 
 	mock := gomock.NewController(t)
 
 	upsRepo := mocks.NewMockUPSRepository(mock)
 	ruleRepo := mocks.NewMockRuleRepository(mock)
 
-	h := NewUPSWakeHandler(config, upsRepo, ruleRepo)
+	h := NewUPSWakeHandler(config, logger, upsRepo, ruleRepo)
 	h.Register(e.Group("/"))
 
 	expectedRoutes := echo.Routes{
@@ -383,11 +387,12 @@ func TestUPSWakeHandler_ListNutServerMappings(t *testing.T) {
 			ruleRepo.EXPECT().Evaluate(gomock.Any(), gomock.Any()).Times(0)
 
 			e := echo.New()
+			logger := slog.New(slog.NewTextHandler(httptest.NewRecorder(), &slog.HandlerOptions{}))
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			h := NewUPSWakeHandler(tt.fields.cfg, upsRepo, ruleRepo)
+			h := NewUPSWakeHandler(tt.fields.cfg, logger, upsRepo, ruleRepo)
 
 			if assert.NoError(t, h.ListNutServerMappings(c)) {
 				assert.JSONEq(t, tt.wantedResponse.body, rec.Body.String())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,27 +46,32 @@ func NewServer(ctx context.Context, logger *slog.Logger) *Server {
 		LogStatus: true,
 		LogURI:    true,
 		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
-			if v.Error != nil {
-				c.Logger().LogAttrs(
-					context.Background(), slog.LevelError, "REQUEST_ERROR",
-					slog.String("remote_ip", c.RealIP()),
-					slog.String("host", c.Request().Host),
-					slog.String("method", c.Request().Method),
-					slog.String("uri", v.URI),
-					slog.String("user_agent", c.Request().UserAgent()),
-					slog.Int("status", v.Status),
-					slog.Any("error", v.Error),
-				)
-				return nil
-			}
-			c.Logger().LogAttrs(
-				context.Background(), slog.LevelInfo, "REQUEST",
+			slogAttrs := []slog.Attr{
 				slog.String("remote_ip", c.RealIP()),
 				slog.String("host", c.Request().Host),
 				slog.String("method", c.Request().Method),
 				slog.String("uri", v.URI),
 				slog.String("user_agent", c.Request().UserAgent()),
 				slog.Int("status", v.Status),
+			}
+
+			if additionalValues := c.Get("request_logger_values"); additionalValues != nil {
+				if attrs, ok := additionalValues.([]slog.Attr); ok {
+					slogAttrs = append(slogAttrs, attrs...)
+				}
+			}
+
+			if v.Error != nil {
+				slogAttrs = append(slogAttrs, slog.String("error", v.Error.Error()))
+				c.Logger().LogAttrs(
+					context.Background(), slog.LevelError, "REQUEST_ERROR",
+					slogAttrs...,
+				)
+				return nil
+			}
+			c.Logger().LogAttrs(
+				context.Background(), slog.LevelInfo, "REQUEST",
+				slogAttrs...,
 			)
 			return nil
 		},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	_ "github.com/TheDarthMole/UPSWake/internal/api/docs" // swaggo docs
+	"github.com/TheDarthMole/UPSWake/internal/logging"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v5"
 	"github.com/labstack/echo/v5/middleware"
@@ -48,10 +49,10 @@ func NewServer(ctx context.Context, logger *slog.Logger) *Server {
 		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
 			slogAttrs := []slog.Attr{
 				slog.String("remote_ip", c.RealIP()),
-				slog.String("host", c.Request().Host),
+				slog.String("host", logging.SanitizeString(c.Request().Host)),
 				slog.String("method", c.Request().Method),
-				slog.String("uri", v.URI),
-				slog.String("user_agent", c.Request().UserAgent()),
+				slog.String("uri", logging.SanitizeString(v.URI)),
+				slog.String("user_agent", logging.SanitizeString(c.Request().UserAgent())),
 				slog.Int("status", v.Status),
 			}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,7 +48,7 @@ func NewServer(ctx context.Context, logger *slog.Logger) *Server {
 		LogURI:    true,
 		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
 			slogAttrs := []slog.Attr{
-				slog.String("remote_ip", c.RealIP()),
+				slog.String("remote_ip", logging.SanitizeString(c.RealIP())),
 				slog.String("host", logging.SanitizeString(c.Request().Host)),
 				slog.String("method", c.Request().Method),
 				slog.String("uri", logging.SanitizeString(v.URI)),

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidBroadcast  = errors.New("broadcast is invalid, must be an IP address")
 	ErrIntervalRequired  = errors.New("interval is required")
 	ErrInvalidInterval   = errors.New("interval is invalid, must be a duration")
+	ErrInvalidLogLevel   = errors.New("log level is invalid")
 	validate             *validator.Validate
 )
 
@@ -57,6 +58,7 @@ func duration(fl validator.FieldLevel) bool {
 
 type Config struct {
 	Profiler   *Profiler
+	Logging    *Logging
 	NutServers []*NutServer
 }
 
@@ -65,6 +67,17 @@ func (c *Config) Validate() error {
 		if err := target.Validate(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+type Logging struct {
+	Level slog.Level
+}
+
+func (l *Logging) Validate() error {
+	if l.Level < slog.LevelDebug || l.Level > slog.LevelInfo {
+		return ErrInvalidLogLevel
 	}
 	return nil
 }

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -76,7 +76,7 @@ type Logging struct {
 }
 
 func (l *Logging) Validate() error {
-	if l.Level < slog.LevelDebug || l.Level > slog.LevelInfo {
+	if l.Level < slog.LevelDebug || l.Level > slog.LevelError {
 		return ErrInvalidLogLevel
 	}
 	return nil

--- a/internal/domain/entity/config_test.go
+++ b/internal/domain/entity/config_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -607,4 +608,66 @@ func TestCreateDefaultConfig(t *testing.T) {
 		assert.Equal(t, DefaultWoLPort, config.NutServers[0].Targets[0].Port)
 		assert.Equal(t, 15*time.Minute, config.NutServers[0].Targets[0].Interval)
 	})
+}
+
+func TestLogging_Validate(t *testing.T) {
+	type fields struct {
+		Level slog.Level
+	}
+	tests := []struct {
+		err    error
+		name   string
+		fields fields
+	}{
+		{
+			name: "debug level",
+			fields: fields{
+				Level: slog.LevelDebug,
+			},
+			err: nil,
+		},
+		{
+			name: "info level",
+			fields: fields{
+				Level: slog.LevelInfo,
+			},
+			err: nil,
+		},
+		{
+			name: "warning level",
+			fields: fields{
+				Level: slog.LevelWarn,
+			},
+			err: nil,
+		},
+		{
+			name: "error level",
+			fields: fields{
+				Level: slog.LevelError,
+			},
+			err: nil,
+		},
+		{
+			name: "level too big",
+			fields: fields{
+				Level: 1000,
+			},
+			err: ErrInvalidLogLevel,
+		},
+		{
+			name: "level too small",
+			fields: fields{
+				Level: -1000,
+			},
+			err: ErrInvalidLogLevel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Logging{
+				Level: tt.fields.Level,
+			}
+			assert.ErrorIs(t, l.Validate(), tt.err)
+		})
+	}
 }

--- a/internal/infrastructure/config/viper/config_mapper.go
+++ b/internal/infrastructure/config/viper/config_mapper.go
@@ -3,6 +3,7 @@ package viper
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/TheDarthMole/UPSWake/internal/domain/entity"
@@ -20,9 +21,15 @@ func FromFileConfig(config *Config) (*entity.Config, error) {
 		nutServers[i] = entityNutServer
 	}
 
+	logLevel, err := FromFileLogging(config.Logging)
+	if err != nil {
+		return nil, err
+	}
+
 	return &entity.Config{
 		NutServers: nutServers,
 		Profiler:   FromFileProfiler(config.Profiler),
+		Logging:    logLevel,
 	}, nil
 }
 
@@ -35,6 +42,7 @@ func ToFileConfig(entityConfig *entity.Config) *Config {
 	return &Config{
 		NutServers: nutServers,
 		Profiler:   ToFileProfiler(entityConfig.Profiler),
+		Logging:    ToFileLogging(entityConfig.Logging),
 	}
 }
 
@@ -117,4 +125,44 @@ func ToFileProfiler(entityProfiler *entity.Profiler) *Profiler {
 		return &Profiler{Enabled: false}
 	}
 	return &Profiler{Enabled: entityProfiler.Enabled}
+}
+
+func FromFileLogging(logging *Logging) (*entity.Logging, error) {
+	if logging == nil {
+		return &entity.Logging{
+			Level: slog.LevelInfo,
+		}, nil
+	}
+	logLevel, err := fromFileLogLevel(logging.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entity.Logging{
+		Level: logLevel,
+	}, nil
+}
+
+func ToFileLogging(entityLogging *entity.Logging) *Logging {
+	if entityLogging == nil {
+		return &Logging{
+			Level: toFileLogLevel(slog.LevelInfo),
+		}
+	}
+	return &Logging{
+		Level: toFileLogLevel(entityLogging.Level),
+	}
+}
+
+func fromFileLogLevel(level string) (slog.Level, error) {
+	lvl := slog.LevelInfo
+	err := lvl.UnmarshalText([]byte(level))
+	if err != nil {
+		return slog.LevelDebug, err
+	}
+	return lvl, nil
+}
+
+func toFileLogLevel(level slog.Level) string {
+	return level.String()
 }

--- a/internal/infrastructure/config/viper/config_mapper_test.go
+++ b/internal/infrastructure/config/viper/config_mapper_test.go
@@ -30,6 +30,9 @@ func TestFromFileConfig(t *testing.T) {
 					Profiler: &Profiler{
 						Enabled: true,
 					},
+					Logging: &Logging{
+						Level: "DEBUG",
+					},
 					NutServers: []*NutServer{
 						{
 							Name:     "TestServer",
@@ -58,7 +61,9 @@ func TestFromFileConfig(t *testing.T) {
 				Profiler: &entity.Profiler{
 					Enabled: true,
 				},
-				Logging: &entity.Logging{},
+				Logging: &entity.Logging{
+					Level: slog.LevelDebug,
+				},
 				NutServers: []*entity.NutServer{
 					{
 						Name:     "TestServer",
@@ -200,10 +205,6 @@ func TestFromFileConfig(t *testing.T) {
 			name: "valid nut server no target servers",
 			args: args{
 				config: &Config{
-					Profiler: &Profiler{},
-					Logging: &Logging{
-						Level: "INFO",
-					},
 					NutServers: []*NutServer{
 						{
 							Name:     "TestServer",
@@ -283,10 +284,6 @@ func TestToFileConfig(t *testing.T) {
 			name: "full entity config with one nut server and one target server",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
-					Logging: &entity.Logging{
-						Level: slog.LevelInfo,
-					},
 					NutServers: []*entity.NutServer{
 						{
 							Name:     "TestServer",
@@ -339,10 +336,6 @@ func TestToFileConfig(t *testing.T) {
 			args: args{
 				entityConfig: &entity.Config{
 					Profiler: nil,
-					Logging: &entity.Logging{
-						Level: slog.LevelInfo,
-					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -358,10 +351,6 @@ func TestToFileConfig(t *testing.T) {
 			args: args{
 				entityConfig: &entity.Config{
 					Profiler: &entity.Profiler{},
-					Logging: &entity.Logging{
-						Level: slog.LevelInfo,
-					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -379,10 +368,6 @@ func TestToFileConfig(t *testing.T) {
 					Profiler: &entity.Profiler{
 						Enabled: true,
 					},
-					Logging: &entity.Logging{
-						Level: slog.LevelInfo,
-					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -399,9 +384,7 @@ func TestToFileConfig(t *testing.T) {
 			name: "nil logging",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler:   &entity.Profiler{},
-					Logging:    nil,
-					NutServers: []*entity.NutServer{},
+					Logging: nil,
 				},
 			},
 			want: &Config{
@@ -416,11 +399,7 @@ func TestToFileConfig(t *testing.T) {
 			name: "empty logging",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
-					Logging: &entity.Logging{
-						Level: slog.LevelInfo,
-					},
-					NutServers: []*entity.NutServer{},
+					Logging: &entity.Logging{},
 				},
 			},
 			want: &Config{
@@ -435,11 +414,9 @@ func TestToFileConfig(t *testing.T) {
 			name: "logging level info",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
 					Logging: &entity.Logging{
 						Level: slog.LevelInfo,
 					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -454,11 +431,9 @@ func TestToFileConfig(t *testing.T) {
 			name: "logging level debug",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
 					Logging: &entity.Logging{
 						Level: slog.LevelDebug,
 					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -473,11 +448,9 @@ func TestToFileConfig(t *testing.T) {
 			name: "logging level warning",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
 					Logging: &entity.Logging{
 						Level: slog.LevelWarn,
 					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
@@ -492,11 +465,9 @@ func TestToFileConfig(t *testing.T) {
 			name: "logging level error",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler: &entity.Profiler{},
 					Logging: &entity.Logging{
 						Level: slog.LevelError,
 					},
-					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{

--- a/internal/infrastructure/config/viper/config_mapper_test.go
+++ b/internal/infrastructure/config/viper/config_mapper_test.go
@@ -1,6 +1,7 @@
 package viper
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -57,6 +58,7 @@ func TestFromFileConfig(t *testing.T) {
 				Profiler: &entity.Profiler{
 					Enabled: true,
 				},
+				Logging: &entity.Logging{},
 				NutServers: []*entity.NutServer{
 					{
 						Name:     "TestServer",
@@ -88,6 +90,109 @@ func TestFromFileConfig(t *testing.T) {
 			},
 			want: &entity.Config{
 				Profiler:   &entity.Profiler{},
+				Logging:    &entity.Logging{},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "profiler enabled",
+			args: args{
+				config: &Config{
+					Profiler: &Profiler{
+						Enabled: true,
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{
+					Enabled: true,
+				},
+				Logging:    &entity.Logging{},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "profiler disabled",
+			args: args{
+				config: &Config{
+					Profiler: &Profiler{
+						Enabled: false,
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{
+					Enabled: false,
+				},
+				Logging:    &entity.Logging{},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "logging debug",
+			args: args{
+				config: &Config{
+					Logging: &Logging{
+						Level: "DEBUG",
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{},
+				Logging: &entity.Logging{
+					Level: slog.LevelDebug,
+				},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "logging info",
+			args: args{
+				config: &Config{
+					Logging: &Logging{
+						Level: "INFO",
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{},
+				Logging: &entity.Logging{
+					Level: slog.LevelInfo,
+				},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "logging warn",
+			args: args{
+				config: &Config{
+					Logging: &Logging{
+						Level: "WARN",
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{},
+				Logging: &entity.Logging{
+					Level: slog.LevelWarn,
+				},
+				NutServers: []*entity.NutServer{},
+			},
+		},
+		{
+			name: "logging error",
+			args: args{
+				config: &Config{
+					Logging: &Logging{
+						Level: "ERROR",
+					},
+				},
+			},
+			want: &entity.Config{
+				Profiler: &entity.Profiler{},
+				Logging: &entity.Logging{
+					Level: slog.LevelError,
+				},
 				NutServers: []*entity.NutServer{},
 			},
 		},
@@ -95,6 +200,10 @@ func TestFromFileConfig(t *testing.T) {
 			name: "valid nut server no target servers",
 			args: args{
 				config: &Config{
+					Profiler: &Profiler{},
+					Logging: &Logging{
+						Level: "INFO",
+					},
 					NutServers: []*NutServer{
 						{
 							Name:     "TestServer",
@@ -109,6 +218,9 @@ func TestFromFileConfig(t *testing.T) {
 			},
 			want: &entity.Config{
 				Profiler: &entity.Profiler{},
+				Logging: &entity.Logging{
+					Level: slog.LevelInfo,
+				},
 				NutServers: []*entity.NutServer{
 					{
 						Name:     "TestServer",
@@ -172,6 +284,9 @@ func TestToFileConfig(t *testing.T) {
 			args: args{
 				entityConfig: &entity.Config{
 					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
 					NutServers: []*entity.NutServer{
 						{
 							Name:     "TestServer",
@@ -195,6 +310,9 @@ func TestToFileConfig(t *testing.T) {
 			},
 			want: &Config{
 				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
 				NutServers: []*NutServer{
 					{
 						Name:     "TestServer",
@@ -220,12 +338,18 @@ func TestToFileConfig(t *testing.T) {
 			name: "nil profiler",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler:   nil,
+					Profiler: nil,
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
 					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
-				Profiler:   &Profiler{},
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
 				NutServers: []*NutServer{},
 			},
 		},
@@ -233,12 +357,18 @@ func TestToFileConfig(t *testing.T) {
 			name: "empty profiler",
 			args: args{
 				entityConfig: &entity.Config{
-					Profiler:   &entity.Profiler{},
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
 					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
-				Profiler:   &Profiler{},
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
 				NutServers: []*NutServer{},
 			},
 		},
@@ -249,12 +379,130 @@ func TestToFileConfig(t *testing.T) {
 					Profiler: &entity.Profiler{
 						Enabled: true,
 					},
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
 					NutServers: []*entity.NutServer{},
 				},
 			},
 			want: &Config{
 				Profiler: &Profiler{
 					Enabled: true,
+				},
+				Logging: &Logging{
+					Level: "INFO",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "nil logging",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler:   &entity.Profiler{},
+					Logging:    nil,
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "empty logging",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "logging level info",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelInfo,
+					},
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "INFO",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "logging level debug",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelDebug,
+					},
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "DEBUG",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "logging level warning",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelWarn,
+					},
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "WARN",
+				},
+				NutServers: []*NutServer{},
+			},
+		},
+		{
+			name: "logging level error",
+			args: args{
+				entityConfig: &entity.Config{
+					Profiler: &entity.Profiler{},
+					Logging: &entity.Logging{
+						Level: slog.LevelError,
+					},
+					NutServers: []*entity.NutServer{},
+				},
+			},
+			want: &Config{
+				Profiler: &Profiler{},
+				Logging: &Logging{
+					Level: "ERROR",
 				},
 				NutServers: []*NutServer{},
 			},

--- a/internal/infrastructure/config/viper/config_test.go
+++ b/internal/infrastructure/config/viper/config_test.go
@@ -37,6 +37,7 @@ func Test_Load(t *testing.T) {
 				Profiler: &entity.Profiler{
 					Enabled: true,
 				},
+				Logging: &entity.Logging{},
 				NutServers: []*entity.NutServer{
 					{
 						Name:     "nut_server_1",
@@ -69,6 +70,7 @@ func Test_Load(t *testing.T) {
 			wantErr: nil,
 			want: &entity.Config{
 				Profiler: &entity.Profiler{},
+				Logging:  &entity.Logging{},
 				NutServers: []*entity.NutServer{
 					{
 						Name:     "nut_server_1",

--- a/internal/infrastructure/config/viper/entities.go
+++ b/internal/infrastructure/config/viper/entities.go
@@ -2,7 +2,12 @@ package viper
 
 type Config struct {
 	Profiler   *Profiler    `mapstructure:"profiler"`
+	Logging    *Logging     `mapstructure:"logging"`
 	NutServers []*NutServer `mapstructure:"nut_servers"`
+}
+
+type Logging struct {
+	Level string
 }
 
 type Profiler struct {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,13 +1,12 @@
 package logging
 
 import (
-	"strconv"
 	"strings"
 )
 
 func SanitizeString(input string) string {
 	// Replace any non-printable characters with an empty string
-	sanitised := strconv.QuoteToASCII(input)
+	sanitised := strings.ReplaceAll(input, `"`, "")
 	sanitised = strings.TrimSpace(sanitised)
 	sanitised = strings.ReplaceAll(sanitised, "\n", "")
 	sanitised = strings.ReplaceAll(sanitised, "\r", "")

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,15 @@
+package logging
+
+import (
+	"strconv"
+	"strings"
+)
+
+func SanitizeString(input string) string {
+	// Replace any non-printable characters with an empty string
+	sanitised := strconv.QuoteToASCII(input)
+	sanitised = strings.TrimSpace(sanitised)
+	sanitised = strings.ReplaceAll(sanitised, "\n", "")
+	sanitised = strings.ReplaceAll(sanitised, "\r", "")
+	return sanitised
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,92 @@
+package logging
+
+import "testing"
+
+func TestSanitizeString(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "empty string",
+			args: args{
+				input: "",
+			},
+			want: "",
+		},
+		{
+			name: "single character",
+			args: args{
+				input: "a",
+			},
+			want: "a",
+		},
+		{
+			name: "single quote",
+			args: args{
+				input: `"`,
+			},
+			want: "",
+		},
+		{
+			name: "double quotes",
+			args: args{
+				input: `""`,
+			},
+			want: "",
+		},
+		{
+			name: "string with quote",
+			args: args{
+				input: `this is a sentence with a "quote" in it`,
+			},
+			want: "this is a sentence with a quote in it",
+		},
+		{
+			name: "newline",
+			args: args{
+				input: "\n",
+			},
+			want: "",
+		},
+		{
+			name: "string with newline",
+			args: args{
+				input: "hey\n",
+			},
+			want: "hey",
+		},
+		{
+			name: "multiple newlines",
+			args: args{
+				input: "hey\n\n",
+			},
+			want: "hey",
+		},
+		{
+			name: "multiple return characters",
+			args: args{
+				input: "hey\r\r",
+			},
+			want: "hey",
+		},
+		{
+			name: "whitespace around text",
+			args: args{
+				input: "   hey   ",
+			},
+			want: "hey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeString(tt.args.input); got != tt.want {
+				t.Errorf("SanitizeString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As mentioned in #356 the logging for the application could do with some love. This PR adds the ability to 

- See the name of the target server and the evaluation result in the HTTP request log
- Debug more of the app's internal flow using the debug mode